### PR TITLE
Kameron fix activity bars

### DIFF
--- a/Bruin Bite/Storyboards/Base.lproj/Main.storyboard
+++ b/Bruin Bite/Storyboards/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="49e-Tb-3d3">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -139,7 +139,7 @@
         <scene sceneID="yl2-sM-qoP">
             <objects>
                 <tabBarController storyboardIdentifier="MainView" id="49e-Tb-3d3" sceneMemberID="viewController">
-                    <tabBar key="tabBar" contentMode="scaleToFill" id="W28-zg-YXA">
+                    <tabBar key="tabBar" contentMode="scaleToFill" translucent="NO" id="W28-zg-YXA">
                         <rect key="frame" x="0.0" y="975" width="768" height="49"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Bruin Bite/View Controllers/MenuVC.swift
+++ b/Bruin Bite/View Controllers/MenuVC.swift
@@ -23,6 +23,8 @@ class MenuVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSo
     var hoursData = [String:[Location:HallHours]]()
     var currDate = "1"
     var currMP = MealPeriod.breakfast
+    var initDate = "1"
+    var initMP = MealPeriod.breakfast
     var currAllergens: [Allergen] = []
     
     var data: [Location: [Item]] = [:]
@@ -87,6 +89,13 @@ class MenuVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSo
             for a in activityLevels{
                 self.activityLevelData.append(a)
             }
+            
+            /* Test Data
+            self.activityLevelData.append(ActivityLevel(isAvailable: true, location: Location.bPlate, percent: 100))
+            self.activityLevelData.append(ActivityLevel(isAvailable: true, location: Location.feast, percent: 90))
+            self.activityLevelData.append(ActivityLevel(isAvailable: true, location: Location.covel, percent: 20))
+            self.activityLevelData.append(ActivityLevel(isAvailable: true, location: Location.deNeve, percent: 50))
+            */
         }
         API.getHours { (hours) in
             for d in hours {
@@ -100,6 +109,9 @@ class MenuVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSo
             let date = Date()
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = "d"
+            
+            self.initDate = dateFormatter.string(from: date)
+            self.initMP = self.currMP
             
             self.updateData(dateFormatter.string(from: date), mP: self.currMP)
         }
@@ -263,10 +275,12 @@ class MenuVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSo
             let text = NSMutableAttributedString(string:"View More", attributes:attrs)
             cell.viewMoreButton.setAttributedTitle(text, for: .normal)
         }
-
+        
+        //Activity Level Loading
         cell.menuCard.activityLevelBar.resizeToZero()
+        cell.menuCard.activityLevelBar.percentage = CGFloat(0)
         for a in activityLevelData{
-            if (a.isAvailable && Array(data.keys)[indexPath.row] == a.location) {
+            if (a.isAvailable && Array(data.keys)[indexPath.row] == a.location && currDate == initDate && currMP == initMP) {
                 cell.menuCard.activityLevelBar.percentage = CGFloat(a.percent)/100
             }
             else if (Array(data.keys)[indexPath.row] == a.location){
@@ -276,6 +290,7 @@ class MenuVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSo
         UIView.animate(withDuration: 1.5, delay: 0, options: .curveEaseInOut, animations: {
             cell.menuCard.activityLevelBar.animateBar()
         }) { (_) in }
+        
         return cell
     }
     

--- a/Bruin Bite/Views/Menu/ActivityLevelBar.swift
+++ b/Bruin Bite/Views/Menu/ActivityLevelBar.swift
@@ -65,6 +65,7 @@ class ActivityLevelBar: UIView {
     
     func animateBar(){
         self.frame.size.width = UIScreen.main.bounds.size.width
+        self.setNeedsDisplay()
     }
 }
 


### PR DESCRIPTION
The activity bar now always represents the right dining hall and only loads when the current meal period is selected.