### PR TITLE
Profile Pictures

### DIFF
--- a/Bruin Bite.xcodeproj/project.pbxproj
+++ b/Bruin Bite.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		002244DC20B8C53000CBD1C2 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002244DB20B8C53000CBD1C2 /* StringExtensions.swift */; };
 		0032C5D52272BC1900841169 /* ChatDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0032C5D42272BC1900841169 /* ChatDetailsViewController.swift */; };
 		0058244F20BA106E0044CB88 /* Hours.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0058244E20BA106E0044CB88 /* Hours.swift */; };
+		00A89A9422851AE500DF78C8 /* ProfilePictureAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00A89A9322851AE500DF78C8 /* ProfilePictureAPI.swift */; };
 		00C207F7221BB422003965FE /* Date+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C207F6221BB422003965FE /* Date+Extension.swift */; };
 		00C2DF0720B677040023CF75 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C2DF0620B677040023CF75 /* User.swift */; };
 		00C2DF0920B678890023CF75 /* Moya.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C2DF0820B678890023CF75 /* Moya.swift */; };
@@ -118,6 +119,7 @@
 		002244DB20B8C53000CBD1C2 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 		0032C5D42272BC1900841169 /* ChatDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatDetailsViewController.swift; sourceTree = "<group>"; };
 		0058244E20BA106E0044CB88 /* Hours.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hours.swift; sourceTree = "<group>"; };
+		00A89A9322851AE500DF78C8 /* ProfilePictureAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilePictureAPI.swift; sourceTree = "<group>"; };
 		00C207F6221BB422003965FE /* Date+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Extension.swift"; sourceTree = "<group>"; };
 		00C2DF0620B677040023CF75 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		00C2DF0820B678890023CF75 /* Moya.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Moya.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 				00C2DF0A20B678A00023CF75 /* UserAPI.swift */,
 				BF0943E320BBFEEF00214200 /* ChatAPI.swift */,
 				BFC934B220C3448A0040D08D /* ChatListAPI.swift */,
+				00A89A9322851AE500DF78C8 /* ProfilePictureAPI.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -505,7 +508,6 @@
 				770251AE201D4079002E4515 /* Resources */,
 				D601296F579F59F8E568D410 /* [CP] Embed Pods Frameworks */,
 				2AFA409F20BBD7A00007FB85 /* Embed App Extensions */,
-				0F0963238FAF47DCE06CAE9A /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -590,21 +592,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		0F0963238FAF47DCE06CAE9A /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Bruin Bite/Pods-Bruin Bite-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		9DB29EBED83346BDBACE0D17 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -701,6 +688,7 @@
 				BF0523E3209AA7E00013EE11 /* ProfileViewController.swift in Sources */,
 				2AFB41372047F0F2004025F9 /* MenuCardCollectionViewCell.swift in Sources */,
 				2A16F9A720BEA204008BA4E3 /* ComingSoonPopup.swift in Sources */,
+				00A89A9422851AE500DF78C8 /* ProfilePictureAPI.swift in Sources */,
 				770CDEAE20266B0800658925 /* ColoredCircle.swift in Sources */,
 				2AB62E702048D21D0013CB59 /* ActivityLevel.swift in Sources */,
 				2AFA40B120BC07AD0007FB85 /* MatchFoundViewController.swift in Sources */,

--- a/Bruin Bite/Network/Moya.swift
+++ b/Bruin Bite/Network/Moya.swift
@@ -23,6 +23,8 @@ enum MainAPI {
     case refreshToken(refresh_token: String)
     case chatList(forUserWithID: Int)
     case last50Messages(forChatRoomLabel: String)
+    case uploadProfilePicture(image: Data)
+    case getProfilePicture(forUserWithID: Int)
 }
 
 extension MainAPI: TargetType {
@@ -57,13 +59,17 @@ extension MainAPI: TargetType {
             return "users/matching/matches"
         case .last50Messages(let chatRoomLbl):
             return "/messaging/messages/\(chatRoomLbl)"
+        case .uploadProfilePicture:
+            return "/users/profile_picture"
+        case .getProfilePicture:
+            return "/users/profile_picture"
         }
     }
     var method: Moya.Method {
         switch self {
-        case .getCurrentActivityLevels, .getOverviewMenu, .getDetailedMenu, .getHours, .readUser, .chatList, .last50Messages:
+        case .getCurrentActivityLevels, .getOverviewMenu, .getDetailedMenu, .getHours, .readUser, .chatList, .last50Messages, .getProfilePicture:
             return .get
-        case .createUser, .loginUser, .matchUser, .refreshToken:
+        case .createUser, .loginUser, .matchUser, .refreshToken, .uploadProfilePicture:
             return .post
         case .updateUser:
             return .put
@@ -93,6 +99,12 @@ extension MainAPI: TargetType {
             return .requestParameters(parameters: ["id": userId], encoding: URLEncoding.default)
         case .last50Messages:
             return .requestParameters(parameters: [:], encoding: URLEncoding.default) // empty because url handled param
+        case .uploadProfilePicture(let profilePicture):
+            let pictureData = MultipartFormData(provider: .data(profilePicture), name: "profile_picture", fileName: "profile.jpeg", mimeType: "multipart/form-data")
+            let multipartData = [pictureData]
+            return .uploadMultipart(multipartData)
+        case .getProfilePicture(let userID):
+            return .requestParameters(parameters: ["user_id": userID], encoding: JSONEncoding.default)
         }
     }
     //for testing
@@ -126,6 +138,10 @@ extension MainAPI: TargetType {
             return Data()
         case .last50Messages:
             return Data()
+        case .uploadProfilePicture:
+            return Data()
+        case .getProfilePicture:
+            return Data()
         }
     }
     var headers: [String: String]? {
@@ -136,7 +152,7 @@ extension MainAPI: TargetType {
             return ["Content-Type": "application/json"]
         case .loginUser, .refreshToken:
             return ["Content-Type": "application/x-www-form-urlencoded"]
-        case .readUser, .updateUser, .deleteUser, .matchUser, .chatList, .last50Messages:
+        case .readUser, .updateUser, .deleteUser, .matchUser, .chatList, .last50Messages, .uploadProfilePicture, .getProfilePicture:
             var temp = "Bearer "
             temp += UserDefaultsManager.shared.getAccessToken()
             return ["Authorization": temp]

--- a/Bruin Bite/Network/Moya.swift
+++ b/Bruin Bite/Network/Moya.swift
@@ -32,7 +32,7 @@ extension MainAPI: TargetType {
         switch self {
         case .getCurrentActivityLevels, .getOverviewMenu, .getDetailedMenu, .getHours:
             return URL(string: "https://api.bruin-bite.com/api/v1")!
-        case .createUser, .readUser, .loginUser, .updateUser, .deleteUser, .matchUser, .refreshToken, .chatList, .last50Messages:
+        case .createUser, .readUser, .loginUser, .updateUser, .deleteUser, .matchUser, .refreshToken, .chatList, .last50Messages, .uploadProfilePicture, .getProfilePicture:
             return URL(string: "https://api.bruin-bite.com/api/v1")!
         }
         

--- a/Bruin Bite/Network/Moya.swift
+++ b/Bruin Bite/Network/Moya.swift
@@ -60,9 +60,9 @@ extension MainAPI: TargetType {
         case .last50Messages(let chatRoomLbl):
             return "/messaging/messages/\(chatRoomLbl)"
         case .uploadProfilePicture:
-            return "/users/profile_picture"
+            return "/users/profile_picture/"
         case .getProfilePicture:
-            return "/users/profile_picture"
+            return "/users/profile_picture/"
         }
     }
     var method: Moya.Method {
@@ -104,7 +104,7 @@ extension MainAPI: TargetType {
             let multipartData = [pictureData]
             return .uploadMultipart(multipartData)
         case .getProfilePicture(let userID):
-            return .requestParameters(parameters: ["user_id": userID], encoding: JSONEncoding.default)
+            return .requestParameters(parameters: ["user_id": userID], encoding: URLEncoding.default)
         }
     }
     //for testing

--- a/Bruin Bite/Network/Moya.swift
+++ b/Bruin Bite/Network/Moya.swift
@@ -34,7 +34,7 @@ extension MainAPI: TargetType {
         switch self {
         case .getCurrentActivityLevels, .getOverviewMenu, .getDetailedMenu, .getHours:
             return URL(string: "https://api.bruin-bite.com/api/v1")!
-        case .createUser, .readUser, .loginUser, .updateUser, .deleteUser, .matchUser, .refreshToken, .chatList, .last50Messages, .unmatchUser, .reportUser, .uploadProfilePicture, .getProfilePicture::
+        case .createUser, .readUser, .loginUser, .updateUser, .deleteUser, .matchUser, .refreshToken, .chatList, .last50Messages, .unmatchUser, .reportUser, .uploadProfilePicture, .getProfilePicture:
             return URL(string: "https://api.bruin-bite.com/api/v1")!
         }
 
@@ -151,6 +151,7 @@ extension MainAPI: TargetType {
         case .reportUser:
             return Data()
         case .unmatchUser:
+            return Data()
         case .uploadProfilePicture:
             return Data()
         case .getProfilePicture:

--- a/Bruin Bite/Network/ProfilePictureAPI.swift
+++ b/Bruin Bite/Network/ProfilePictureAPI.swift
@@ -10,8 +10,8 @@ import Foundation
 import Moya
 
 struct ProfilePictureResponse: Codable {
-    let userID: Int
-    let profilePicture: String
+    let user_id: Int
+    let profile_picture: String
 }
 
 protocol ProfilePictureUploadDelegate {
@@ -57,7 +57,7 @@ class ProfilePictureAPI {
                     delegate.profilePicture(failedWithError: self.DOWNLOAD_ERR_MSG)
                     return
                 }
-                guard let dataDecoded : Data = Data(base64Encoded: resultStruct.profilePicture, options: .ignoreUnknownCharacters), let image = UIImage(data: dataDecoded) else {
+                guard let dataDecoded : Data = Data(base64Encoded: resultStruct.profile_picture, options: .ignoreUnknownCharacters), let image = UIImage(data: dataDecoded) else {
                     print("Error: Could not decode profile picture")
                     delegate.profilePicture(failedWithError: self.DOWNLOAD_ERR_MSG)
                     return

--- a/Bruin Bite/Network/ProfilePictureAPI.swift
+++ b/Bruin Bite/Network/ProfilePictureAPI.swift
@@ -1,0 +1,72 @@
+//
+//  ProfilePictureAPI.swift
+//  Bruin Bite
+//
+//  Created by Kameron Carr on 5/9/19.
+//  Copyright © 2019 Dont Eat Alone. All rights reserved.
+//
+
+import Foundation
+import Moya
+
+struct ProfilePictureResponse: Codable {
+    let userID: Int
+    let profilePicture: String
+}
+
+protocol ProfilePictureUploadDelegate {
+    func profilePicture(uploadCompleted: Bool, failedWithError error: String?)
+}
+
+protocol ProfilePictureDownloadDelegate {
+    func profilePicture(didDownloadimage image: UIImage)
+    func profilePicture(failedWithError error: String?)
+}
+
+class ProfilePictureAPI {
+    
+    private let provider = MoyaProvider<MainAPI>()
+    
+    private let UPLOAD_ERR_MSG = "Couldn't upload profile picture. Try again later"
+    private let DOWNLOAD_ERR_MSG = "Couldn't download profile picture. Try again later"
+    
+    func upload(profilePicture: UIImage, delegate: ProfilePictureUploadDelegate){
+        if let data = UIImageJPEGRepresentation(profilePicture, 0.7){
+            provider.request(.uploadProfilePicture(image: data)) { (result) in
+                switch(result){
+                case let .success(response):
+                    if response.statusCode == 201 {
+                        delegate.profilePicture(uploadCompleted: true, failedWithError: nil)
+                    } else {
+                        delegate.profilePicture(uploadCompleted: false, failedWithError: self.UPLOAD_ERR_MSG)
+                    }
+                case let .failure(error):
+                    print("Could not upload photo: " + (error.errorDescription ?? ""))
+                    delegate.profilePicture(uploadCompleted: false, failedWithError: self.UPLOAD_ERR_MSG)
+                }
+            }
+        }
+    }
+    
+    func download(pictureForUserID userID: Int, delegate: ProfilePictureDownloadDelegate){
+        provider.request(.getProfilePicture(forUserWithID: userID)) { (result) in
+            switch(result){
+            case let .success(response):
+                guard let resultStruct : ProfilePictureResponse = try? JSONDecoder().decode(ProfilePictureResponse.self, from: response.data) else {
+                    print("Error: Could not decode profile picture response struct.")
+                    delegate.profilePicture(failedWithError: self.DOWNLOAD_ERR_MSG)
+                    return
+                }
+                guard let dataDecoded : Data = Data(base64Encoded: resultStruct.profilePicture, options: .ignoreUnknownCharacters), let image = UIImage(data: dataDecoded) else {
+                    print("Error: Could not decode profile picture")
+                    delegate.profilePicture(failedWithError: self.DOWNLOAD_ERR_MSG)
+                    return
+                }
+                delegate.profilePicture(didDownloadimage: image)
+            case let .failure(error):
+                print("Could not download photo: " + (error.errorDescription ?? ""))
+                delegate.profilePicture(failedWithError: self.DOWNLOAD_ERR_MSG)
+            }
+        }
+    }
+}

--- a/Bruin Bite/Network/ProfilePictureAPI.swift
+++ b/Bruin Bite/Network/ProfilePictureAPI.swift
@@ -19,7 +19,7 @@ protocol ProfilePictureUploadDelegate {
 }
 
 protocol ProfilePictureDownloadDelegate {
-    func profilePicture(didDownloadimage image: UIImage)
+    func profilePicture(didDownloadimage image: UIImage, forUserWithID userID: Int)
     func profilePicture(failedWithError error: String?)
 }
 
@@ -31,7 +31,7 @@ class ProfilePictureAPI {
     private let DOWNLOAD_ERR_MSG = "Couldn't download profile picture. Try again later"
     
     func upload(profilePicture: UIImage, delegate: ProfilePictureUploadDelegate){
-        if let data = UIImageJPEGRepresentation(profilePicture, 0.7){
+        if let data = UIImageJPEGRepresentation(profilePicture, 0.4){
             provider.request(.uploadProfilePicture(image: data)) { (result) in
                 switch(result){
                 case let .success(response):
@@ -62,7 +62,7 @@ class ProfilePictureAPI {
                     delegate.profilePicture(failedWithError: self.DOWNLOAD_ERR_MSG)
                     return
                 }
-                delegate.profilePicture(didDownloadimage: image)
+                delegate.profilePicture(didDownloadimage: image, forUserWithID: userID)
             case let .failure(error):
                 print("Could not download photo: " + (error.errorDescription ?? ""))
                 delegate.profilePicture(failedWithError: self.DOWNLOAD_ERR_MSG)

--- a/Bruin Bite/Storyboards/Login.storyboard
+++ b/Bruin Bite/Storyboards/Login.storyboard
@@ -482,6 +482,7 @@
                         <outlet property="BioText" destination="UPG-fQ-gga" id="b75-IE-DSu"/>
                         <outlet property="BioTextBox" destination="hOe-iL-nsr" id="afH-TX-Iu9"/>
                         <outlet property="BioTextBoxChar" destination="7eg-dc-dIU" id="s1s-hv-CSf"/>
+                        <outlet property="nextButton" destination="o1y-ub-wYw" id="1ez-he-r1J"/>
                         <segue destination="aNE-gY-fgK" kind="show" identifier="toCreateController" id="kCm-77-NrQ"/>
                     </connections>
                 </viewController>

--- a/Bruin Bite/Storyboards/Login.storyboard
+++ b/Bruin Bite/Storyboards/Login.storyboard
@@ -423,6 +423,14 @@
                                     <action selector="nextButtonPressed:" destination="Mdq-9S-8BC" eventType="touchUpInside" id="bQa-4v-NDz"/>
                                 </connections>
                             </button>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="h8a-dl-SMT">
+                                <rect key="frame" x="270.5" y="310" width="30" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="30" id="gV6-U1-Ab5"/>
+                                    <constraint firstAttribute="width" constant="30" id="hrm-wt-7d2"/>
+                                </constraints>
+                                <color key="color" red="0.194423914" green="0.37402850389999998" blue="0.5412153006" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            </activityIndicatorView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BIO" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UPG-fQ-gga">
                                 <rect key="frame" x="69.5" y="168" width="173" height="20.5"/>
                                 <constraints>
@@ -465,6 +473,8 @@
                             <constraint firstItem="hOe-iL-nsr" firstAttribute="top" secondItem="UPG-fQ-gga" secondAttribute="bottom" constant="5.5" id="7oc-4f-DhH"/>
                             <constraint firstItem="hOe-iL-nsr" firstAttribute="width" secondItem="aEk-LL-qZK" secondAttribute="height" multiplier="242:603" id="9X0-vd-U6I"/>
                             <constraint firstItem="7eg-dc-dIU" firstAttribute="width" secondItem="aEk-LL-qZK" secondAttribute="height" multiplier="35:603" id="Cdl-3s-QxI"/>
+                            <constraint firstItem="h8a-dl-SMT" firstAttribute="centerX" secondItem="o1y-ub-wYw" secondAttribute="centerX" id="HAI-5E-EN5"/>
+                            <constraint firstItem="h8a-dl-SMT" firstAttribute="centerY" secondItem="o1y-ub-wYw" secondAttribute="centerY" id="ZWF-1C-mjT"/>
                             <constraint firstItem="o1y-ub-wYw" firstAttribute="top" secondItem="hOe-iL-nsr" secondAttribute="bottom" constant="35" id="d0x-40-9ta"/>
                             <constraint firstItem="hOe-iL-nsr" firstAttribute="centerX" secondItem="aEk-LL-qZK" secondAttribute="centerX" id="dbM-iD-RTF"/>
                             <constraint firstItem="WdP-dU-tHJ" firstAttribute="width" secondItem="aEk-LL-qZK" secondAttribute="height" multiplier="139:603" id="eQ2-kz-qdD"/>
@@ -478,6 +488,7 @@
                         <viewLayoutGuide key="safeArea" id="yIp-xP-33L"/>
                     </view>
                     <connections>
+                        <outlet property="ActivityIndicator" destination="h8a-dl-SMT" id="hpO-8U-sqF"/>
                         <outlet property="BioPic" destination="WdP-dU-tHJ" id="byy-JQ-gwo"/>
                         <outlet property="BioText" destination="UPG-fQ-gga" id="b75-IE-DSu"/>
                         <outlet property="BioTextBox" destination="hOe-iL-nsr" id="afH-TX-Iu9"/>

--- a/Bruin Bite/View Controllers/ChatListViewController.swift
+++ b/Bruin Bite/View Controllers/ChatListViewController.swift
@@ -117,6 +117,7 @@ class ChatListViewController: UIViewController, UITableViewDelegate, UITableView
     
     func profilePicture(didDownloadimage image: UIImage, forUserWithID userID: Int) {
         profilePictures[userID] = image
+        self.chatListTableView.reloadData()
     }
     
     func profilePicture(failedWithError error: String?) {

--- a/Bruin Bite/View Controllers/ChatListViewController.swift
+++ b/Bruin Bite/View Controllers/ChatListViewController.swift
@@ -18,9 +18,10 @@ class ChatListTableViewCell: UITableViewCell {
     @IBOutlet weak var unreadMessagesLabel: UILabel!
 }
 
-class ChatListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, ChatListDelegate, LoginAlertPresentable {
+class ChatListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource, ChatListDelegate, LoginAlertPresentable, ProfilePictureDownloadDelegate {
 
     var data: [ChatListItem] = []
+    var profilePictures: [Int : UIImage] = [:]
     var selectedChat: ChatListItem? = nil
     
     let chatListAPI: ChatListAPI = ChatListAPI()
@@ -65,6 +66,7 @@ class ChatListViewController: UIViewController, UITableViewDelegate, UITableView
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ChatListCell", for: indexPath) as! ChatListTableViewCell
         cell.nameLabel.text = data[indexPath.row].user2_first_name + " " + data[indexPath.row].user2_last_name
+        cell.profileImage.image = profilePictures[data[indexPath.row].user2] ?? UIImage(named: "DefaultProfile")
         var dateString = ""
         var timeString = ""
         if let date = getDateObject(fromDateTimeString: data[indexPath.row].meal_datetime) {
@@ -92,6 +94,9 @@ class ChatListViewController: UIViewController, UITableViewDelegate, UITableView
     
     func didReceiveChatList(chatListData: [ChatListItem]) {
         self.data = chatListData
+        for chatListItem in data{
+            ProfilePictureAPI().download(pictureForUserID: chatListItem.user2, delegate: self)
+        }
         self.chatListTableView.reloadData()
     }
     
@@ -110,6 +115,13 @@ class ChatListViewController: UIViewController, UITableViewDelegate, UITableView
         }
     }
     
+    func profilePicture(didDownloadimage image: UIImage, forUserWithID userID: Int) {
+        profilePictures[userID] = image
+    }
+    
+    func profilePicture(failedWithError error: String?) {
+        print("Could not download profile photo\(error ?? "")")
+    }
     
     // UTILITY FUNCTIONS:
     

--- a/Bruin Bite/View Controllers/CreateProfileViewController.swift
+++ b/Bruin Bite/View Controllers/CreateProfileViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresentable, UITextViewDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresentable, UITextViewDelegate, UIImagePickerControllerDelegate, UINavigationControllerDelegate, ProfilePictureUploadDelegate {
 
     var profilePic: UIImage!
     var imagePickerController: UIImagePickerController?
@@ -114,9 +114,19 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
                 self.BioPic.layer.cornerRadius = BioPic.frame.height/2
                 self.profilePic = pickedImage
                 self.BioPic.image = pickedImage
+            ProfilePictureAPI().upload(profilePicture: pickedImage, delegate: self)
         }
 
         dismiss(animated: true, completion: nil)
+    }
+    
+    func profilePicture(uploadCompleted: Bool, failedWithError error: String?) {
+        if(uploadCompleted){
+            print("YAYYYYYY")
+        }
+        else {
+            print("Hirday is going to fire you: " + (error ?? ""))
+        }
     }
 
     func textView(_ BioTextBox: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {

--- a/Bruin Bite/View Controllers/CreateProfileViewController.swift
+++ b/Bruin Bite/View Controllers/CreateProfileViewController.swift
@@ -121,11 +121,8 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
     }
     
     func profilePicture(uploadCompleted: Bool, failedWithError error: String?) {
-        if(uploadCompleted){
-            print("YAYYYYYY")
-        }
-        else {
-            print("Hirday is going to fire you: " + (error ?? ""))
+        if(!uploadCompleted){
+            print("Failed to upload profile picture: " + (error ?? ""))
         }
     }
 

--- a/Bruin Bite/View Controllers/CreateProfileViewController.swift
+++ b/Bruin Bite/View Controllers/CreateProfileViewController.swift
@@ -15,6 +15,8 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
     
     @IBOutlet weak var BioPic: UIImageView!
     @IBOutlet var BioText: UILabel!
+    @IBOutlet weak var NextButton: UIButton!
+    
 
     //@IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     @IBOutlet var BioTextBox: UITextView!
@@ -34,7 +36,7 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
         BioText.font = UIFont.bioFont
         BioTextBox.becomeFirstResponder()
         BioTextBox.delegate = self
-
+        NextButton.isEnabled = false
         Utilities.sharedInstance.formatNavigation(controller: self.navigationController!)
         self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor : UIColor.white, NSAttributedStringKey.font: UIFont(name: "AvenirNext-Bold", size: 17.0)!]
 
@@ -121,13 +123,17 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
     }
     
     func profilePicture(uploadCompleted: Bool, failedWithError error: String?) {
-        if(!uploadCompleted){
+        if(uploadCompleted){
+            NextButton.isEnabled = true
+        }
+        else {
             print("Failed to upload profile picture: " + (error ?? ""))
             let alert = UIAlertController(title: "Upload Failed", message: "Your photo could not be uploaded at this time. Please try again later.", preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { _ in
                 self.BioPic.image = UIImage(named: "ProfilePic")
             }))
             self.present(alert, animated: true, completion: nil)
+            NextButton.isEnabled = false
         }
     }
 

--- a/Bruin Bite/View Controllers/CreateProfileViewController.swift
+++ b/Bruin Bite/View Controllers/CreateProfileViewController.swift
@@ -16,6 +16,7 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
     @IBOutlet weak var BioPic: UIImageView!
     @IBOutlet var BioText: UILabel!
     @IBOutlet weak var NextButton: UIButton!
+    @IBOutlet weak var ActivityIndicator: UIActivityIndicatorView!
     
 
     //@IBOutlet weak var activityIndicator: UIActivityIndicatorView!
@@ -36,7 +37,8 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
         BioText.font = UIFont.bioFont
         BioTextBox.becomeFirstResponder()
         BioTextBox.delegate = self
-        NextButton.isEnabled = false
+        ActivityIndicator.hidesWhenStopped = true
+        
         Utilities.sharedInstance.formatNavigation(controller: self.navigationController!)
         self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedStringKey.foregroundColor : UIColor.white, NSAttributedStringKey.font: UIFont(name: "AvenirNext-Bold", size: 17.0)!]
 
@@ -112,11 +114,13 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
 
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
         if let pickedImage = info[UIImagePickerControllerOriginalImage] as? UIImage {
-
-                self.BioPic.layer.cornerRadius = BioPic.frame.height/2
-                self.profilePic = pickedImage
-                self.BioPic.image = pickedImage
+            self.BioPic.layer.cornerRadius = BioPic.frame.height/2
+            self.profilePic = pickedImage
+            self.BioPic.image = pickedImage
+            
             ProfilePictureAPI().upload(profilePicture: pickedImage, delegate: self)
+            NextButton.isEnabled = false
+            ActivityIndicator.startAnimating()
         }
 
         dismiss(animated: true, completion: nil)
@@ -125,6 +129,7 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
     func profilePicture(uploadCompleted: Bool, failedWithError error: String?) {
         if(uploadCompleted){
             NextButton.isEnabled = true
+            ActivityIndicator.stopAnimating()
         }
         else {
             print("Failed to upload profile picture: " + (error ?? ""))
@@ -133,7 +138,8 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
                 self.BioPic.image = UIImage(named: "ProfilePic")
             }))
             self.present(alert, animated: true, completion: nil)
-            NextButton.isEnabled = false
+            NextButton.isEnabled = true
+            ActivityIndicator.stopAnimating()
         }
     }
 

--- a/Bruin Bite/View Controllers/CreateProfileViewController.swift
+++ b/Bruin Bite/View Controllers/CreateProfileViewController.swift
@@ -123,6 +123,11 @@ class CreateProfileViewController: UIViewController, UpdateDelegate, AlertPresen
     func profilePicture(uploadCompleted: Bool, failedWithError error: String?) {
         if(!uploadCompleted){
             print("Failed to upload profile picture: " + (error ?? ""))
+            let alert = UIAlertController(title: "Upload Failed", message: "Your photo could not be uploaded at this time. Please try again later.", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .default, handler: { _ in
+                self.BioPic.image = UIImage(named: "ProfilePic")
+            }))
+            self.present(alert, animated: true, completion: nil)
         }
     }
 

--- a/Bruin Bite/View Controllers/ProfileViewController.swift
+++ b/Bruin Bite/View Controllers/ProfileViewController.swift
@@ -56,7 +56,7 @@ class ProfileViewController: UIViewController, ReadDelegate, AlertPresentable, L
         ProfilePictureAPI().download(pictureForUserID: UserManager.shared.getUID(), delegate: self)
     }
     
-    func profilePicture(didDownloadimage image: UIImage) {
+    func profilePicture(didDownloadimage image: UIImage, forUserWithID _: Int) {
         profilePic.image = image
     }
     

--- a/Bruin Bite/View Controllers/ProfileViewController.swift
+++ b/Bruin Bite/View Controllers/ProfileViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import Foundation
 
-class ProfileViewController: UIViewController, ReadDelegate, AlertPresentable, LoginAlertPresentable {
+class ProfileViewController: UIViewController, ReadDelegate, AlertPresentable, LoginAlertPresentable, ProfilePictureDownloadDelegate {
 
     @IBOutlet weak var profilePic: UIImageView!
     @IBOutlet weak var userName: UILabel!
@@ -52,6 +52,16 @@ class ProfileViewController: UIViewController, ReadDelegate, AlertPresentable, L
         fillInformation()
         //Set the labels/profile picture with default or old information
         UserManager.shared.readUser(email: UserDefaultsManager.shared.getUserEmail())
+        
+        ProfilePictureAPI().download(pictureForUserID: UserManager.shared.getUID(), delegate: self)
+    }
+    
+    func profilePicture(didDownloadimage image: UIImage) {
+        profilePic.image = image
+    }
+    
+    func profilePicture(failedWithError error: String?) {
+        print("Failed to download profile picture: \(error ?? "")")
     }
 
     func didReadUser() {


### PR DESCRIPTION
Closes #128 

You can now upload and download Profile pictures.
Simply call the `ProfilePictureAPI` functions `upload` and `download`.

Upload ability was implemented for when the user creates their profile while signing up.
Users will be alerted if the picture fails to upload.
<img width="584" alt="image" src="https://user-images.githubusercontent.com/24720843/57507537-f5334080-72b3-11e9-8a12-20feb4f4de61.png">

The download ability was implemented for when the user goes to their own profile.