### PR TITLE
Implementation of timestamps in chat

### DIFF
--- a/Bruin Bite/Storyboards/Chat.storyboard
+++ b/Bruin Bite/Storyboards/Chat.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -206,7 +206,7 @@
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <subviews>
                                                         <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Label" translatesAutoresizingMaskIntoConstraints="NO" id="KV0-SQ-Wy1" customClass="DesignableTextView" customModule="Bruin_Bite" customModuleProvider="target">
-                                                            <rect key="frame" x="15" y="8" width="73" height="44"/>
+                                                            <rect key="frame" x="15" y="19" width="73" height="38"/>
                                                             <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="17"/>
                                                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -220,7 +220,7 @@
                                                             </userDefinedRuntimeAttributes>
                                                         </textView>
                                                         <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Label" translatesAutoresizingMaskIntoConstraints="NO" id="Eye-S8-SSV" customClass="DesignableTextView" customModule="Bruin_Bite" customModuleProvider="target">
-                                                            <rect key="frame" x="287" y="8" width="73" height="44"/>
+                                                            <rect key="frame" x="287" y="19" width="73" height="38"/>
                                                             <color key="backgroundColor" red="0.027450980392156862" green="0.29019607843137252" blue="0.46666666666666667" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <inset key="scrollIndicatorInsets" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                             <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -235,21 +235,30 @@
                                                                 </userDefinedRuntimeAttribute>
                                                             </userDefinedRuntimeAttributes>
                                                         </textView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kNt-mT-jDq" userLabel="Timestamp">
+                                                            <rect key="frame" x="187.5" y="2" width="0.0" height="0.0"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
                                                     </subviews>
                                                     <constraints>
                                                         <constraint firstItem="KV0-SQ-Wy1" firstAttribute="leading" secondItem="E1X-qB-6A2" secondAttribute="leading" constant="15" id="MjH-KP-c4M"/>
-                                                        <constraint firstItem="Eye-S8-SSV" firstAttribute="top" secondItem="E1X-qB-6A2" secondAttribute="top" constant="8" id="S7G-Nb-NYS"/>
-                                                        <constraint firstItem="KV0-SQ-Wy1" firstAttribute="top" secondItem="E1X-qB-6A2" secondAttribute="top" constant="8" id="cqS-cC-WMk"/>
+                                                        <constraint firstItem="Eye-S8-SSV" firstAttribute="top" secondItem="E1X-qB-6A2" secondAttribute="top" constant="19" id="S7G-Nb-NYS"/>
+                                                        <constraint firstItem="kNt-mT-jDq" firstAttribute="top" secondItem="E1X-qB-6A2" secondAttribute="top" constant="2" id="VPz-mo-hNL"/>
+                                                        <constraint firstItem="KV0-SQ-Wy1" firstAttribute="top" secondItem="E1X-qB-6A2" secondAttribute="top" constant="19" id="cqS-cC-WMk"/>
                                                         <constraint firstItem="KV0-SQ-Wy1" firstAttribute="width" relation="lessThanOrEqual" secondItem="E1X-qB-6A2" secondAttribute="width" multiplier="0.75" id="deq-V1-l0n"/>
                                                         <constraint firstAttribute="trailing" secondItem="Eye-S8-SSV" secondAttribute="trailing" constant="15" id="eJL-2r-MGy"/>
+                                                        <constraint firstItem="kNt-mT-jDq" firstAttribute="centerX" secondItem="E1X-qB-6A2" secondAttribute="centerX" id="efI-HU-eua"/>
                                                         <constraint firstItem="Eye-S8-SSV" firstAttribute="width" relation="lessThanOrEqual" secondItem="E1X-qB-6A2" secondAttribute="width" multiplier="0.75" id="gN5-ZU-SgW"/>
-                                                        <constraint firstAttribute="bottom" secondItem="KV0-SQ-Wy1" secondAttribute="bottom" constant="8" id="hVE-Ig-1Fp"/>
-                                                        <constraint firstAttribute="bottom" secondItem="Eye-S8-SSV" secondAttribute="bottom" constant="8" id="iAd-8Y-EUh"/>
+                                                        <constraint firstAttribute="bottom" secondItem="KV0-SQ-Wy1" secondAttribute="bottom" constant="3" id="hVE-Ig-1Fp"/>
+                                                        <constraint firstAttribute="bottom" secondItem="Eye-S8-SSV" secondAttribute="bottom" constant="3" id="iAd-8Y-EUh"/>
                                                     </constraints>
                                                 </tableViewCellContentView>
                                                 <connections>
                                                     <outlet property="receivedMessageLabel" destination="KV0-SQ-Wy1" id="xtT-Ni-4Gw"/>
                                                     <outlet property="sentMessageLabel" destination="Eye-S8-SSV" id="qth-uo-IcV"/>
+                                                    <outlet property="timestampLabel" destination="kNt-mT-jDq" id="oEp-ly-UVS"/>
                                                 </connections>
                                             </tableViewCell>
                                         </prototypes>

--- a/Bruin Bite/View Controllers/ChatScreenViewController.swift
+++ b/Bruin Bite/View Controllers/ChatScreenViewController.swift
@@ -117,17 +117,15 @@ class ChatScreenViewController: UIViewController, UITableViewDelegate, UITableVi
         let prevIndexRow = indexPath.row - 1
         var displayTimestamp = false
         
-        if(prevIndexRow >= 0)
+        if(prevIndexRow >= 0)   //Always show the most recent timestamp
         {
             let previousTimestamp = messagesList[prevIndexRow].timestamp
-            print(previousTimestamp)
             displayTimestamp = decideToDisplayTimestamp(prevTimestamp: previousTimestamp, currTimestamp: currentTimestamp)
         }
         else
         {
             displayTimestamp = true
         }
-        
         if(displayTimestamp)
         {
             cell.timestampLabel.text = formattedTimestamp
@@ -143,6 +141,7 @@ class ChatScreenViewController: UIViewController, UITableViewDelegate, UITableVi
     
     func decideToDisplayTimestamp(prevTimestamp: String, currTimestamp: String) -> Bool
     {
+        //decide whether or not to display the timestamp based on the duration between the current timestamp and the previous timestamp. Returns true if the interval between messages is > 300.
         var interval = Double()
         var postJustMade = false
         //Convert both the previous date stored int the class and the date passed into the function from strings to date objects

--- a/Bruin Bite/View Controllers/ChatScreenViewController.swift
+++ b/Bruin Bite/View Controllers/ChatScreenViewController.swift
@@ -21,7 +21,7 @@ enum ChatPopupType{
 class MessageBubbleCell: UITableViewCell {
     @IBOutlet weak var receivedMessageLabel: UITextView!
     @IBOutlet weak var sentMessageLabel: UITextView!
-
+    @IBOutlet weak var timestampLabel: UILabel!
     var debugData: ChatMessage = ChatMessage(timestamp: "", handle: "", message: "")
 }
 
@@ -109,9 +109,71 @@ class ChatScreenViewController: UIViewController, UITableViewDelegate, UITableVi
             cell.receivedMessageLabel.isHidden = false
             cell.receivedMessageLabel.text = currMessage.message
         }
+        
+        //Timestamp code
+        let currentTimestamp = currMessage.timestamp
+        let formattedTimestamp = currMessage.timestamp.toDateString(inputDateFormat: "yyyy-MM-dd'T'HH:mm:ss.SSSZ", ouputDateFormat: "hh:mm a MMM dd")
+        
+        let prevIndexRow = indexPath.row - 1
+        var displayTimestamp = false
+        
+        if(prevIndexRow >= 0)
+        {
+            let previousTimestamp = messagesList[prevIndexRow].timestamp
+            print(previousTimestamp)
+            displayTimestamp = decideToDisplayTimestamp(prevTimestamp: previousTimestamp, currTimestamp: currentTimestamp)
+        }
+        else
+        {
+            displayTimestamp = true
+        }
+        
+        if(displayTimestamp)
+        {
+            cell.timestampLabel.text = formattedTimestamp
+        }
+        else
+        {
+            cell.timestampLabel.text = ""
+        }
         cell.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi));
         cell.sizeToFit()
         return cell
+    }
+    
+    func decideToDisplayTimestamp(prevTimestamp: String, currTimestamp: String) -> Bool
+    {
+        var interval = Double()
+        var postJustMade = false
+        //Convert both the previous date stored int the class and the date passed into the function from strings to date objects
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+
+        let objectPrevTimestamp = dateFormatter.date(from: prevTimestamp)
+        
+        let objectCurrTimestamp = dateFormatter.date(from: currTimestamp)
+        
+        if(!(objectPrevTimestamp != nil) || !(objectCurrTimestamp != nil))
+        {
+            postJustMade = true
+        }
+        
+        if (postJustMade == false)
+        {
+            interval = objectPrevTimestamp!.timeIntervalSince(objectCurrTimestamp!)
+        }
+        else
+        {
+            interval = 0
+        }
+        if (interval >= 300)
+        {
+            return true
+        }
+        else
+        {
+            return false
+        }
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -294,5 +356,16 @@ class ChatScreenViewController: UIViewController, UITableViewDelegate, UITableVi
              dest.time = "6:00 pm"
             */
         }
+    }
+}
+extension String
+{
+    func toDateString( inputDateFormat inputFormat  : String,  ouputDateFormat outputFormat  : String ) -> String
+    {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = inputFormat
+        let date = dateFormatter.date(from: self)
+        dateFormatter.dateFormat = outputFormat
+        return dateFormatter.string(from: date ?? Date())
     }
 }

--- a/Bruin Bite/View Controllers/SignUpViewController.swift
+++ b/Bruin Bite/View Controllers/SignUpViewController.swift
@@ -67,6 +67,11 @@ class SignUpViewController: UIViewController, SignupDelegate, LoginDelegate, Ale
             Utilities.sharedInstance.displayErrorLabel(text: "Enter a valid email", field: EmailText)
             return
         }
+        if(!(EmailText.text?.contains("@ucla.edu") ?? false))
+        {
+            Utilities.sharedInstance.displayErrorLabel(text: "Please use your @ucla.edu email", field: EmailText)
+            return
+        }
         if((PasswordText.text ?? "") != ConfirmPassText.text ) { //I was worried about nil == nil
             Utilities.sharedInstance.displayErrorLabel(text: "Passwords do not match", field: ConfirmPassText)
             return


### PR DESCRIPTION
Full implementation of timestamps in the chat. Each timestamp is added during the cell generation process of each chat cell. The timestamp info is grabbed from the already existing information and is applied as gray text next to the chat bubbles. The function decideToDisplayTimestamp() then decides whether to display the timestamp depending on whether the previous message in the chat has a timestamp at least 300 seconds prior (Thus meaning that a timestamp is not displayed for every single message but only messages after a period of no interaction)